### PR TITLE
Allows you to filter TimeEntry with parameters from_date and to_date

### DIFF
--- a/docs/resources/time_entry.rst
+++ b/docs/resources/time_entry.rst
@@ -62,7 +62,10 @@ Supported keyword arguments:
 
 Supported filters:
 
-* **spent_on**. Hours spent on what date.
+* **spent_on**. Hours spent on what date. (this could not work in some redmine
+  versions)
+* **from_date**. Limit the TimeEntry from this date 
+* **to_date** . Limit the TimeEntry until this date
 * **project_id**. Get time entries from the project with the given id, where id
   is either project id or project identifier.
 * **user_id**. Get time entries for the given user id
@@ -70,7 +73,7 @@ Supported filters:
 
 .. code-block:: python
 
-    >>> time_entries = redmine.user.filter(offset=10, limit=100, project_id='vacation', hours='>=8')
+    >>> time_entries = redmine.time_entry.filter(offset=10, limit=100, project_id='vacation', hours='>=8')
     >>> time_entries
     <redmine.resultsets.ResourceSet object with TimeEntry resources>
 

--- a/redmine/__init__.py
+++ b/redmine/__init__.py
@@ -65,7 +65,10 @@ class Redmine(object):
             kwargs['params']['key'] = self.key
         else:
             kwargs['auth'] = (self.username, self.password)
-
+        if 'from_date' in kwargs['params']:
+            kwargs['params']['from'] = kwargs['params'].pop('from_date')
+        if 'to_date' in kwargs['params']:
+            kwargs['params']['to'] = kwargs['params'].pop('to_date')
         response = getattr(requests, method)(url, **kwargs)
 
         if response.status_code in (200, 201):

--- a/redmine/managers.py
+++ b/redmine/managers.py
@@ -37,7 +37,6 @@ class ResourceManager(object):
     def retrieve(self, **params):
         """A proxy for Redmine object request which does some extra work for resource retrieval"""
         self.params.update(**params)
-
         # Redmine allows us to only return 100 resources per request, so if
         # we want to get all or > 100 resources we need to do some extra work
         if 'limit' in self.params and not 0 < self.params['limit'] <= 100:

--- a/redmine/resources.py
+++ b/redmine/resources.py
@@ -215,7 +215,8 @@ class TimeEntry(_Resource):
     container_create = 'time_entry'
     query_all = '/time_entries.json'
     query_one = '/time_entries/{0}.json'
-    query_filter = '/issues/{issue_id}/time_entries.json'
+    # query_filter = '/issues/{issue_id}/time_entries.json'
+    query_filter = '/time_entries.json'
     query_create = '/time_entries.json'
     query_delete = '/time_entries/{0}.json'
 


### PR DESCRIPTION
as the spend_on parameter and others filters does not work, I've checked what redmine does in the web and added the same parameters. As from is a reserved word I've changed to from_date and to_date to be more clear.

Actually this allows you to filter TimeEntries in an range of days.
