### PR TITLE
allow disable ssl verification and specify certificate files

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -52,6 +52,33 @@ Most of the time, the API requires authentication. It can be done in 2 different
 The API key can be found on users account page when logged in, on the right-hand pane of
 the default layout.
 
+SSL Cert Verification
++++++++++++++++++++++
+
+You can verify SSL certificates for HTTPS requests, just like a web browser. To check a host's SSL certificate, you can use the ``sslverify`` argument: 
+
+.. code-block:: python
+
+    redmine = Redmine('https://demo.redmine.org', sslverify=True)
+
+It's also possible to ignore verifying the SSL certificate if you set ``sslverify`` to False.
+
+.. code-block:: python
+
+    redmine = Redmine('https://demo.redmine.org', sslverify=False)
+
+By default, sslverify is set to True, Option sslverify only applies to host certs.
+
+You can also specify a local cert to use as client side certificate, as a single file (containing the private key and the certificate) or as a tuple of both file’s path:
+
+.. code-block:: python
+
+    redmine = Redmine('https://demo.redmine.org', sslcert=('/path/server.crt', '/path/key'))
+
+.. code-block:: python
+
+    redmine = Redmine('https://demo.redmine.org', sslcert='/path/server.pem')
+
 Impersonation
 +++++++++++++
 

--- a/redmine/__init__.py
+++ b/redmine/__init__.py
@@ -27,6 +27,8 @@ class Redmine(object):
         self.impersonate = kwargs.get('impersonate', None)
         self.date_format = kwargs.get('date_format', '%Y-%m-%d')
         self.datetime_format = kwargs.get('datetime_format', '%Y-%m-%dT%H:%M:%SZ')
+        self.sslverify = kwargs.get('sslverify', None)
+        self.sslcert = kwargs.get('sslcert', None)
 
     def __getattr__(self, resource):
         """Returns either ResourceSet or Resource object depending on the method used on the ResourceManager"""
@@ -66,6 +68,11 @@ class Redmine(object):
             kwargs['params']['key'] = self.key
         else:
             kwargs['auth'] = (self.username, self.password)
+
+        if self.sslverify is not None:
+            kwargs['verify'] = self.sslverify
+        if self.sslcert is not None:
+            kwargs['cert'] = self.sslcert
 
         response = getattr(requests, method)(url, **kwargs)
 


### PR DESCRIPTION
Added options to disable SSL verification and to specify SSL certificate for validation. Those options are available in Python-Requests module used by Python-Redmine project.
