### PR TITLE
 fix return a blank in redmin 1.3.3, throw JSONDecodeError

### DIFF
--- a/redmine/__init__.py
+++ b/redmine/__init__.py
@@ -72,7 +72,7 @@ class Redmine(object):
         response = getattr(requests, method)(url, **kwargs)
 
         if response.status_code in (200, 201):
-            if not response.content:
+            if not response.content.strip():
                 return True
             return response.json()
         elif response.status_code == 401:


### PR DESCRIPTION
fix -return a blank in redmin 1.3.3, throw JSONDecodeError
