### PR TITLE
update exceptions.py

### DIFF
--- a/redmine/exceptions.py
+++ b/redmine/exceptions.py
@@ -102,7 +102,7 @@ class ResourceNoFieldsProvidedError(BaseRedmineError):
         super(ResourceNoFieldsProvidedError, self).__init__('Resource needs some fields to be set to be created/updated')
 
 
-class ResourceAttrError(BaseRedmineError):
+class ResourceAttrError(BaseRedmineError, AttributeError):
     """Resource doesn't have the requested attribute"""
     def __init__(self):
         super(ResourceAttrError, self).__init__("Resource doesn't have the requested attribute")


### PR DESCRIPTION
Now, ResourceAttrError is a subclass of AttributeError.  These exceptions can now be caught as AttributeError exceptions by application code or standard library stuff.  getattr comes to mind.
