### PR TITLE
Fixed a TypeError with join in __init__ for 422 responses

### DIFF
--- a/redmine/__init__.py
+++ b/redmine/__init__.py
@@ -129,7 +129,10 @@ class Redmine(object):
         elif response.status_code == 413:
             raise RequestEntityTooLargeError
         elif response.status_code == 422:
-            raise ValidationError(to_string(', '.join(json_response(response.json)['errors'])))
+            errors = json_response(response.json)['errors']
+            if not all([isinstance(e, basestring) for e in errors]):
+                errors = [': '.join(e) for e in errors]
+            raise ValidationError(to_string(', '.join(errors)))
         elif response.status_code == 500:
             raise ServerError
 


### PR DESCRIPTION
On your latest revision with Chiliproject 3.8.0 I got the following exception when creating an issue with a parent outside of the selected project:

```
File "redmine/__init__.py", line 132, in request
    raise ValidationError(to_string(', '.join(json_response(response.json)['errors'])))
TypeError: sequence item 0: expected string, list found
```

I fixed this problem for my case by joining twice if not all errors are strings.

Now it raises a ValidationError with the following message:

```
parent_issue_id: doesn't belong to the same project
```
