### PR TITLE
Raise ForbiddenError when a 403 is encountered

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Changelog
   raised during processing validation errors from Redmine when one of the errors was returned as
   a list)
 
+- Fixed: `Issue #59 <https://github.com/maxtepkeev/python-redmine/issues/59>`__ (Raise ForbiddenError when a 403 is encountered)
+
 1.0.1 (2014-09-23)
 ++++++++++++++++++
 

--- a/redmine/__init__.py
+++ b/redmine/__init__.py
@@ -16,7 +16,8 @@ from redmine.exceptions import (
     VersionMismatchError,
     ResourceNotFoundError,
     RequestEntityTooLargeError,
-    UnknownError
+    UnknownError,
+    ForbiddenError
 )
 
 
@@ -120,6 +121,8 @@ class Redmine(object):
                 return json_response(response.json)
         elif response.status_code == 401:
             raise AuthError
+        elif response.status_code == 403:
+            raise ForbiddenError
         elif response.status_code == 404:
             raise ResourceNotFoundError
         elif response.status_code == 409:

--- a/redmine/exceptions.py
+++ b/redmine/exceptions.py
@@ -156,3 +156,9 @@ class FileUrlError(BaseRedmineError):
     """URL provided to download a file can't be parsed"""
     def __init__(self):
         super(FileUrlError, self).__init__("URL provided to download a file can't be parsed")
+
+
+class ForbiddenError(BaseRedmineError):
+    """Requested resource is forbidden"""
+    def __init__(self):
+        super(ForbiddenError, self).__init__("Requested resource is forbidden")

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -120,6 +120,11 @@ class TestRedmineRequest(unittest.TestCase):
         self.response.status_code = 401
         self.assertRaises(AuthError, lambda: self.redmine.request('get', self.url))
 
+    def test_forbidden_error_exception(self):
+        from redmine.exceptions import ForbiddenError
+        self.response.status_code = 403
+        self.assertRaises(ForbiddenError, lambda: self.redmine.request('get', self.url))
+
     def test_impersonate_error_exception(self):
         from redmine.exceptions import ImpersonateError
         self.redmine.impersonate = 'not_exists'


### PR DESCRIPTION
Replaces the `UnknownError` that was previously raised.

Fixes #59
