### PR TITLE
Adding in support to get attributes by attribute

### DIFF
--- a/redmine/managers.py
+++ b/redmine/managers.py
@@ -114,14 +114,7 @@ class ResourceManager(object):
 
     def get_all_by_attribute(self, name, value):
         """Returns an attribute by filtering down all items by name == value"""
-        found = []
-        for item in self.all():
-            if getattr(item, name) == value:
-                found.append(item)
-        if found:
-            return found
-        else:
-            raise ResourceNotFoundError
+        return (item for item in self.all() if getattr(item, name) == value)
 
     def get(self, resource_id, **params):
         """Returns a Resource object directly by resource id (can be either integer id or string identifier)"""

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -111,13 +111,23 @@ class TestResourceManager(unittest.TestCase):
         self.assertEqual(resourceset[1].id, 2)
 
     @mock.patch('requests.get')
-    def test_get_all_resource_by_attribute_missing_attribute(self, mock_get):
+    def test_get_all_by_attribute_returns_generator(self, mock_get):
+        import types
+        trackers = {
+            'trackers':
+                [
+                    {'name': 'Foo', 'id': 1},
+                    {'name': 'Foo', 'id': 2},
+                    {'name': 'Bar', 'id': 3},
+                ]
+        }
         mock_get.return_value = response = mock.Mock(status_code=200)
-        response.json = json_response({'trackers': [{'name': 'Foo', 'id': 1}, {'name': 'Bar', 'id': 2}]})
-        self.assertRaises(ResourceAttrError, lambda: self.redmine.tracker.get_all_by_attribute('missing', 'Foo'))
+        response.json = json_response(trackers)
+        foo = self.redmine.tracker.get_all_by_attribute('name','Foo')
+        self.assertIsInstance(foo, types.GeneratorType)
 
     @mock.patch('requests.get')
-    def test_get_all_resource_by_attribute(self, mock_get):
+    def test_get_all_by_attribute(self, mock_get):
         trackers = {
             'trackers':
                 [
@@ -138,10 +148,10 @@ class TestResourceManager(unittest.TestCase):
         self.assertEqual(3, bar[0].id)
 
     @mock.patch('requests.get')
-    def test_get_all_resource_by_attribute_missing(self, mock_get):
+    def test_get_all_by_attribute_returns_empty_recordset(self, mock_get):
         mock_get.return_value = response = mock.Mock(status_code=200)
         response.json = json_response({'trackers': []})
-        self.assertRaises(ResourceNotFoundError, lambda: self.redmine.tracker.get_all_by_attribute('foo','bar'))
+        self.assertEqual([], list(self.redmine.tracker.get_all_by_attribute('foo','bar')))
 
     @mock.patch('requests.get')
     def test_get_single_resource(self, mock_get):


### PR DESCRIPTION
Maybe I am doing it wrong, but there are a lot of cases that I want to get say a tracker or custom_field by name. Since the Redmine API does not support this it makes it difficult and you have to essentially fetch all records and then filter them down manually.

This should essentially do that process instead of having the api user write their own function

Does it make sense to support a non-lazy operation though?
