### PR TITLE
Make `Redmine` class picklable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Changelog
   a list)
 - Fixed: `Issue #59 <https://github.com/maxtepkeev/python-redmine/issues/59>`__ (Raise ForbiddenError
   when a 403 is encountered) (thanks to `Rick Harris <https://github.com/rconradharris>`__)
+- Fixed: `Issue #64 <https://github.com/maxtepkeev/python-redmine/issues/64>`__ (Make the Redmine class picklable) (thanks to `Rick Harris <https://github.com/rconradharris>`__)
 
 1.0.1 (2014-09-23)
 ++++++++++++++++++

--- a/redmine/__init__.py
+++ b/redmine/__init__.py
@@ -38,6 +38,9 @@ class Redmine(object):
 
     def __getattr__(self, resource):
         """Returns either ResourceSet or Resource object depending on the method used on the ResourceManager"""
+        if resource.startswith('_'):
+            raise AttributeError
+
         return ResourceManager(self, resource)
 
     def upload(self, filepath):

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -163,3 +163,12 @@ class TestRedmineRequest(unittest.TestCase):
         self.response.status_code = 200
         self.response.json = json_response({'user': {'firstname': 'John', 'lastname': 'Smith', 'id': 1}})
         self.assertEqual(self.redmine.auth().firstname, 'John')
+
+    def test_getattr_on_under_attribute(self):
+        """
+        Attributes that begin with an underscore should not be treated as a
+        `Resource`. The impetus of this was to make `Redmine` picklable by
+        preventing the `__getstate__` access from being treated a `Resource`.
+        """
+        with self.assertRaises(AttributeError):
+            self.redmine.__getstate__


### PR DESCRIPTION
The `Redmine` class couldn't be pickled because the `gettatr` would attempt to
turn any attribute access into a `Resource`, even `__getstate__`.

The proposed fix treats attributes that begin with an underscore (and
double-underscore) as non-`Resource` attributes and returns their value as-is.

Fixes #64
