### PR TITLE
Fix unicode resource_id

### DIFF
--- a/redmine/managers.py
+++ b/redmine/managers.py
@@ -3,7 +3,7 @@ import datetime
 from distutils.version import LooseVersion
 
 from .resultsets import ResourceSet
-from .utilities import MemorizeFormatter
+from .utilities import MemorizeFormatter, is_unicode, to_string
 from .exceptions import (
     ResourceError,
     ResourceBadMethodError,
@@ -119,6 +119,8 @@ class ResourceManager(object):
         if self.resource_class.query_one is None or self.resource_class.container_one is None:
             raise ResourceBadMethodError
 
+        if is_unicode(resource_id):
+            resource_id = to_string(resource_id)
         try:
             self.url = '{0}{1}'.format(self.redmine.url, self.resource_class.query_one.format(resource_id, **params))
         except KeyError as exception:

--- a/redmine/utilities.py
+++ b/redmine/utilities.py
@@ -7,6 +7,11 @@ def is_string(string):
     return isinstance(string, basestring if sys.version_info[0] < 3 else str)
 
 
+def is_unicode(string):
+    """Python 2 and 3 friendly function to check if an object is a unicode string"""
+    return isinstance(string, unicode if sys.version_info[0] < 3 else str)
+
+
 def to_string(string):
     """Converts unicode to utf-8 if on Python 2, leaves as is if on Python 3"""
     return string.encode('utf-8') if sys.version_info[0] < 3 else string

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -57,6 +57,16 @@ class TestResourceManager(unittest.TestCase):
         self.assertEqual(project.identifier, 'foo')
         self.assertEqual(project.id, 1)
 
+    @mock.patch('redmine.requests.get')
+    def test_get_unicode_resource(self, mock_get):
+        mock_get.return_value = response = mock.Mock(status_code=200)
+        unicode_name = b'\xcf\x86oo'.decode('utf8')
+        response.json.return_value = {'project': {'name': unicode_name, 'identifier': unicode_name, 'id': 1}}
+        project = self.redmine.project.get(unicode_name)
+        self.assertEqual(project.name, unicode_name)
+        self.assertEqual(project.identifier, unicode_name)
+        self.assertEqual(project.id, 1)
+
     def test_get_all_resources(self):
         self.assertIsInstance(self.redmine.project.all(), ResourceSet)
 


### PR DESCRIPTION
As described #112,
wiki pages with a unicode name
result in the error in the d5c3971 build for py2.