### PR TITLE
Add globally available method to allow for uploading binary object

### DIFF
--- a/redminelib/__init__.py
+++ b/redminelib/__init__.py
@@ -71,40 +71,25 @@ class Redmine(object):
         yield self
         self.engine = engine
 
-    def upload(self, filepath):
+    def upload(self, filepath_obj):
         """
         Uploads file from filepath to Redmine and returns an assigned token.
 
-        :param string filepath: (required). Path to the file that will be uploaded.
+        :param string filepath_obj: (required). Path to the file or filestream that will be uploaded.
         """
         if self.ver is not None and LooseVersion(str(self.ver)) < LooseVersion('1.4.0'):
             raise exceptions.VersionMismatchError('File uploading')
-
-        if not os.path.isfile(filepath) or os.path.getsize(filepath) == 0:
-            raise exceptions.NoFileError
-
-        with open(filepath, 'rb') as stream:
-            url = '{0}/uploads.json'.format(self.url)
-            headers = {'Content-Type': 'application/octet-stream'}
-            response = self.engine.request('post', url, data=stream, headers=headers)
-
-        return response['upload']['token']
-
-    def upload_object(self, fileobj):
-        """
-        Uploads binary file object to Redmine and returns an assigned token.
-
-        :param string fileobj: (required). File object that will be uploaded.
-        """
-        if self.ver is not None and LooseVersion(str(self.ver)) < LooseVersion('1.4.0'):
-            raise exceptions.VersionMismatchError('File uploading')
-
-        if not isinstance(fileobj, file):
-            raise exceptions.NoFileError
 
         url = '{0}/uploads.json'.format(self.url)
         headers = {'Content-Type': 'application/octet-stream'}
-        response = self.engine.request('post', url, data=fileobj, headers=headers)
+        if isinstance(filepath_obj, file):
+            response = self.engine.request('post', url, data=filepath_obj, headers=headers)
+        else:
+            if not os.path.isfile(filepath_obj) or os.path.getsize(filepath_obj) == 0:
+                raise exceptions.NoFileError
+            with open(filepath_obj, 'rb') as stream:
+                response = self.engine.request('post', url, data=stream, headers=headers)
+
         return response['upload']['token']
 
     def download(self, url, savepath=None, filename=None, params=None):

--- a/redminelib/__init__.py
+++ b/redminelib/__init__.py
@@ -82,7 +82,13 @@ class Redmine(object):
 
         url = '{0}/uploads.json'.format(self.url)
         headers = {'Content-Type': 'application/octet-stream'}
-        if isinstance(filepath_obj, file):
+        try:
+            from StringIO import StringIO
+            filetype = (file, StringIO)
+        except (NameError, ImportError):
+            from io import IOBase
+            filetype = IOBase
+        if isinstance(filepath_obj, filetype):
             response = self.engine.request('post', url, data=filepath_obj, headers=headers)
         else:
             if not os.path.isfile(filepath_obj) or os.path.getsize(filepath_obj) == 0:

--- a/redminelib/__init__.py
+++ b/redminelib/__init__.py
@@ -90,6 +90,23 @@ class Redmine(object):
 
         return response['upload']['token']
 
+    def upload_object(self, fileobj):
+        """
+        Uploads binary file object to Redmine and returns an assigned token.
+
+        :param string fileobj: (required). File object that will be uploaded.
+        """
+        if self.ver is not None and LooseVersion(str(self.ver)) < LooseVersion('1.4.0'):
+            raise exceptions.VersionMismatchError('File uploading')
+
+        if not isinstance(fileobj, file):
+            raise exceptions.NoFileError
+
+        url = '{0}/uploads.json'.format(self.url)
+        headers = {'Content-Type': 'application/octet-stream'}
+        response = self.engine.request('post', url, data=fileobj, headers=headers)
+        return response['upload']['token']
+
     def download(self, url, savepath=None, filename=None, params=None):
         """
         Downloads file from Redmine and saves it to savepath or returns a response directly


### PR DESCRIPTION
I think instead of having a different method, it can be managed by the same `upload` call.

References #186.