### PR TITLE
Support special characters in wiki page titles.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-*.pyc
-.coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+.coverage

--- a/redminelib/managers/base.py
+++ b/redminelib/managers/base.py
@@ -149,7 +149,7 @@ class ResourceManager(object):
         if not fields:
             raise exceptions.ResourceNoFieldsProvidedError
 
-        formatter = utilities.MemorizeFormatter()
+        formatter = utilities.MemorizeURIFormatter()
 
         try:
             url = self._construct_create_url(formatter.format(self.resource_class.query_create, **fields))
@@ -203,7 +203,7 @@ class ResourceManager(object):
         if not fields:
             raise exceptions.ResourceNoFieldsProvidedError
 
-        formatter = utilities.MemorizeFormatter()
+        formatter = utilities.MemorizeURIFormatter()
 
         try:
             query_update = formatter.format(self.resource_class.query_update, resource_id, **fields)

--- a/redminelib/resources/base.py
+++ b/redminelib/resources/base.py
@@ -19,6 +19,8 @@ class Registrar(type):
     which name starts with Base are considered base classes and not added to the registry.
     """
     def __new__(mcs, name, bases, attrs):
+        mcs.update_query_strings(attrs)
+
         cls = super(Registrar, mcs).__new__(mcs, name, bases, attrs)
 
         if name.startswith('Base'):  # base classes shouldn't be added to the registry
@@ -52,6 +54,16 @@ class Registrar(type):
                     mcs.update_cls_attr(registry[resource_name]['class'], '_resource_set_map', {value: name})
 
         return registry[name].setdefault('class', cls)
+
+    @staticmethod
+    def update_query_strings(attrs):
+        """
+        Updates all `query_*` string attributes to use ResourceQueryFormatter by defalt.
+        """
+        for k, v in attrs.items():
+            if k.startswith('query_') and isinstance(v, utilities.text_type):
+                attrs[k] = utilities.ResourceQueryStr(v)
+        return attrs
 
     @staticmethod
     def update_cls_attr(cls, name, value):

--- a/redminelib/resources/base.py
+++ b/redminelib/resources/base.py
@@ -58,10 +58,10 @@ class Registrar(type):
     @staticmethod
     def update_query_strings(attrs):
         """
-        Updates all `query_*` string attributes to use ResourceQueryFormatter by defalt.
+        Updates all `query_*` string attributes to use ResourceQueryFormatter by default.
         """
         for k, v in attrs.items():
-            if k.startswith('query_') and isinstance(v, utilities.text_type):
+            if k.startswith('query_') and v is not None:
                 attrs[k] = utilities.ResourceQueryStr(v)
         return attrs
 

--- a/redminelib/resources/standard.py
+++ b/redminelib/resources/standard.py
@@ -8,6 +8,7 @@ from distutils.version import LooseVersion
 
 from . import BaseResource
 from .. import managers, exceptions
+from ..utilities import URITemplate
 
 
 class Project(BaseResource):
@@ -258,12 +259,12 @@ class WikiPage(BaseResource):
     container_one = 'wiki_page'
     container_create = 'wiki_page'
     container_update = 'wiki_page'
-    query_one_export = '/projects/{project_id}/wiki/{0}.{format}'
+    query_one_export = URITemplate('/projects/{project_id}/wiki/{0}.{format}')
     query_filter = '/projects/{project_id}/wiki/index.json'
-    query_one = '/projects/{project_id}/wiki/{0}.json'
-    query_create = '/projects/{project_id}/wiki/{title}.json'
-    query_update = '/projects/{project_id}/wiki/{0}.json'
-    query_delete = '/projects/{project_id}/wiki/{0}.json'
+    query_one = URITemplate('/projects/{project_id}/wiki/{0}.json')
+    query_create = URITemplate('/projects/{project_id}/wiki/{title}.json')
+    query_update = URITemplate('/projects/{project_id}/wiki/{0}.json')
+    query_delete = URITemplate('/projects/{project_id}/wiki/{0}.json')
     search_hints = ['wiki-page']
     http_method_create = 'put'
     manager_class = managers.WikiPageManager

--- a/redminelib/resources/standard.py
+++ b/redminelib/resources/standard.py
@@ -8,7 +8,6 @@ from distutils.version import LooseVersion
 
 from . import BaseResource
 from .. import managers, exceptions
-from ..utilities import URITemplate
 
 
 class Project(BaseResource):
@@ -202,12 +201,13 @@ class Enumeration(BaseResource):
     redmine_version = '2.2'
     container_filter = '{resource}'
     query_filter = '/enumerations/{resource}.json'
+    query_url = '/enumerations/{0}/edit'
 
     _resource_set_map = {'custom_fields': 'CustomField'}
 
     @property
     def url(self):
-        return '{0}/enumerations/{1}/edit'.format(self.manager.redmine.url, self.internal_id)
+        return self.manager.redmine.url + self.query_url.format(self.internal_id)
 
 
 class Attachment(BaseResource):
@@ -259,12 +259,12 @@ class WikiPage(BaseResource):
     container_one = 'wiki_page'
     container_create = 'wiki_page'
     container_update = 'wiki_page'
-    query_one_export = URITemplate('/projects/{project_id}/wiki/{0}.{format}')
+    query_one_export = '/projects/{project_id}/wiki/{0}.{format}'
     query_filter = '/projects/{project_id}/wiki/index.json'
-    query_one = URITemplate('/projects/{project_id}/wiki/{0}.json')
-    query_create = URITemplate('/projects/{project_id}/wiki/{title}.json')
-    query_update = URITemplate('/projects/{project_id}/wiki/{0}.json')
-    query_delete = URITemplate('/projects/{project_id}/wiki/{0}.json')
+    query_one = '/projects/{project_id}/wiki/{0}.json'
+    query_create = '/projects/{project_id}/wiki/{title}.json'
+    query_update = '/projects/{project_id}/wiki/{0}.json'
+    query_delete = '/projects/{project_id}/wiki/{0}.json'
     search_hints = ['wiki-page']
     http_method_create = 'put'
     manager_class = managers.WikiPageManager
@@ -490,6 +490,7 @@ class News(BaseResource):
     query_all_export = '/news.{format}'
     query_all = '/news.json'
     query_filter = '/news.json'
+    query_url = '/news/{0}'
     search_hints = ['news']
 
     _repr = [['id', 'title']]
@@ -497,13 +498,14 @@ class News(BaseResource):
 
     @property
     def url(self):
-        return '{0}/news/{1}'.format(self.manager.redmine.url, self.internal_id)
+        return self.manager.redmine.url + self.query_url.format(self.internal_id)
 
 
 class IssueStatus(BaseResource):
     redmine_version = '1.3'
     container_all = 'issue_statuses'
     query_all = '/issue_statuses.json'
+    query_url = '/issue_statuses/{0}/edit'
 
     _relations = ['issues']
     _relations_name = 'status'
@@ -511,37 +513,40 @@ class IssueStatus(BaseResource):
 
     @property
     def url(self):
-        return '{0}/issue_statuses/{1}/edit'.format(self.manager.redmine.url, self.internal_id)
+        return self.manager.redmine.url + self.query_url.format(self.internal_id)
 
 
 class Tracker(BaseResource):
     redmine_version = '1.3'
     container_all = 'trackers'
     query_all = '/trackers.json'
+    query_url = '/trackers/{0}/edit'
 
     _relations = ['issues']
     _resource_set_map = {'issues': 'Issue'}
 
     @property
     def url(self):
-        return '{0}/trackers/{1}/edit'.format(self.manager.redmine.url, self.internal_id)
+        return self.manager.redmine.url + self.query_url.format(self.internal_id)
 
 
 class Query(BaseResource):
     redmine_version = '1.3'
     container_all = 'queries'
     query_all = '/queries.json'
+    query_url = '/projects/{0}/issues?query_id={1}'
 
     @property
     def url(self):
-        return '{0}/projects/{1}/issues?query_id={2}'.format(
-            self.manager.redmine.url, self._decoded_attrs.get('project_id', 0), self.internal_id)
+        return self.manager.redmine.url + self.query_url.format(
+            self._decoded_attrs.get('project_id', 0), self.internal_id)
 
 
 class CustomField(BaseResource):
     redmine_version = '2.4'
     container_all = 'custom_fields'
     query_all = '/custom_fields.json'
+    query_url = '/custom_fields/{0}/edit'
 
     _resource_set_map = {'trackers': 'Tracker', 'roles': 'Role'}
 
@@ -567,4 +572,4 @@ class CustomField(BaseResource):
 
     @property
     def url(self):
-        return '{0}/custom_fields/{1}/edit'.format(self.manager.redmine.url, self.internal_id)
+        return self.manager.redmine.url + self.query_url.format(self.internal_id)

--- a/redminelib/resultsets.py
+++ b/redminelib/resultsets.py
@@ -53,7 +53,7 @@ class BaseResourceSet(object):
         if self.manager.resource_class.query_all_export is None:
             raise exceptions.ExportNotSupported
 
-        formatter = utilities.MemorizeFormatter()
+        formatter = utilities.MemorizeURIFormatter()
 
         url = self.manager.redmine.url + formatter.format(
             self.manager.resource_class.query_all_export, format=fmt, **self.manager.params)

--- a/redminelib/resultsets.py
+++ b/redminelib/resultsets.py
@@ -6,7 +6,7 @@ import operator
 import functools
 import itertools
 
-from . import lookups, utilities, exceptions
+from . import lookups, exceptions
 
 
 class BaseResourceSet(object):
@@ -53,13 +53,11 @@ class BaseResourceSet(object):
         if self.manager.resource_class.query_all_export is None:
             raise exceptions.ExportNotSupported
 
-        formatter = utilities.MemorizeURIFormatter()
-
-        url = self.manager.redmine.url + formatter.format(
-            self.manager.resource_class.query_all_export, format=fmt, **self.manager.params)
+        url = self.manager.redmine.url + self.manager.resource_class.query_all_export.format(
+                format=fmt, **self.manager.params)
 
         try:
-            return self.manager.redmine.download(url, savepath, filename, params=formatter.unused_kwargs)
+            return self.manager.redmine.download(url, savepath, filename, params=self.manager.resource_class.query_all_export.formatter.unused_kwargs)
         except exceptions.UnknownError as e:
             if e.status_code == 406:
                 raise exceptions.ExportFormatNotSupportedError

--- a/redminelib/utilities.py
+++ b/redminelib/utilities.py
@@ -6,14 +6,13 @@ import sys
 import copy
 import string
 import functools
+
 try:
     # Python 3
     from urllib.parse import quote
-    text_type = str
 except ImportError:
     # Python 2
     from urllib import quote
-    text_type = unicode
 
 
 def fix_unicode(cls):

--- a/redminelib/utilities.py
+++ b/redminelib/utilities.py
@@ -7,9 +7,13 @@ import copy
 import string
 import functools
 try:
+    # Python 3
     from urllib.parse import quote
+    text_type = str
 except ImportError:
+    # Python 2
     from urllib import quote
+    text_type = unicode
 
 
 def fix_unicode(cls):
@@ -69,18 +73,9 @@ def merge_dicts(a, b):
     return result
 
 
-class URIFormatter(string.Formatter):
+class ResourceQueryFormatter(string.Formatter):
     """
-    Passes all arguments through urllib.parse.quote.
-    """
-    def format_field(self, value, format_spec):
-        retval = super(URIFormatter, self).format_field(value, format_spec)
-        return quote(retval.encode('utf-8'))
-
-
-class MemorizeURIFormatter(URIFormatter):
-    """
-    Memorizes all arguments, used during string formatting.
+    Quotes query and memorizes all arguments, used during string formatting.
     """
     def __init__(self):
         self.used_kwargs = {}
@@ -93,9 +88,12 @@ class MemorizeURIFormatter(URIFormatter):
 
         self.unused_kwargs = kwargs
 
+    def format_field(self, value, format_spec):
+        return quote(super(ResourceQueryFormatter, self).format_field(value, format_spec).encode('utf-8'))
 
-class URITemplate(str):
-    formatter = URIFormatter()
+
+class ResourceQueryStr(str):
+    formatter = ResourceQueryFormatter()
 
     def format(self, *args, **kwargs):
-        return URIFormatter().format(self, *args, **kwargs)
+        return self.formatter.format(self, *args, **kwargs)

--- a/redminelib/utilities.py
+++ b/redminelib/utilities.py
@@ -6,6 +6,10 @@ import sys
 import copy
 import string
 import functools
+try:
+    from urllib.parse import quote
+except ImportError:
+    from urllib import quote
 
 
 def fix_unicode(cls):
@@ -65,7 +69,16 @@ def merge_dicts(a, b):
     return result
 
 
-class MemorizeFormatter(string.Formatter):
+class URIFormatter(string.Formatter):
+    """
+    Passes all arguments through urllib.parse.quote.
+    """
+    def format_field(self, value, format_spec):
+        retval = super(URIFormatter, self).format_field(value, format_spec)
+        return quote(retval.encode('utf-8'))
+
+
+class MemorizeURIFormatter(URIFormatter):
     """
     Memorizes all arguments, used during string formatting.
     """
@@ -79,3 +92,10 @@ class MemorizeFormatter(string.Formatter):
                 self.used_kwargs[item] = kwargs.pop(item)
 
         self.unused_kwargs = kwargs
+
+
+class URITemplate(str):
+    formatter = URIFormatter()
+
+    def format(self, *args, **kwargs):
+        return URIFormatter().format(self, *args, **kwargs)

--- a/tests/responses/standard.py
+++ b/tests/responses/standard.py
@@ -24,6 +24,7 @@ responses = {
     },
     'wiki_page': {
         'get': {'wiki_page': {'title': 'Foo', 'version': 1}},
+        'get_special': {'wiki_page': {'title': 'Foo%Bar', 'version': 1}},
         'filter': {'wiki_pages': [{'title': 'Foo', 'version': 1}, {'title': 'Bar', 'version': 2}]},
     },
     'project_membership': {

--- a/tests/test_resources_standard.py
+++ b/tests/test_resources_standard.py
@@ -702,6 +702,17 @@ class StandardResourcesTestCase(BaseRedmineTestCase):
         wiki_page = self.redmine.wiki_page.get('Foo', project_id=1)
         self.assertEqual(wiki_page.title, 'Foo')
 
+    def test_wiki_page_get_special(self):
+        """Test getting a wiki page with special char in title."""
+        self.response.json.return_value = responses['wiki_page']['get_special']
+        wiki_page = self.redmine.wiki_page.get('Foo%Bar', project_id=1)
+        self.assertEqual(
+            self.patch_requests.call_args[0][1],
+            '{0}/projects/1/wiki/Foo%25Bar.json'.format(self.url)
+        )
+        self.assertEqual(wiki_page.title, 'Foo%Bar')
+        self.assertEqual(wiki_page.url, 'http://foo.bar/projects/1/wiki/Foo%25Bar')
+
     def test_wiki_page_filter(self):
         self.response.json.return_value = responses['wiki_page']['filter']
         wiki_pages = self.redmine.wiki_page.filter(project_id=1)
@@ -713,6 +724,17 @@ class StandardResourcesTestCase(BaseRedmineTestCase):
         self.response.json.return_value = responses['wiki_page']['get']
         wiki_page = self.redmine.wiki_page.create(project_id='foo', title='Foo')
         self.assertEqual(wiki_page.title, 'Foo')
+
+    def test_wiki_page_create_special(self):
+        """Test creating a wiki page with special char in title."""
+        self.response.status_code = 201
+        self.response.json.return_value = responses['wiki_page']['get_special']
+        wiki_page = self.redmine.wiki_page.create(project_id='foo', title='Foo%Bar')
+        self.assertEqual(
+            self.patch_requests.call_args[0][1],
+            '{0}/projects/foo/wiki/Foo%25Bar.json'.format(self.url)
+        )
+        self.assertEqual(wiki_page.title, 'Foo%Bar')
 
     def test_wiki_page_delete(self):
         self.response.json.return_value = responses['wiki_page']['get']


### PR DESCRIPTION
Redmine wiki pages titles can contain characters which need to be URL-encoded. This means the titles can't be pasted verbatim into the URL templates.

This change introduces a `string.Formatter` subclass which `urrlib.parse.quote`s the argument, and uses that to format the URLs where wiki page titles are used.