### PR TITLE
fix send_information for user creation and update

### DIFF
--- a/redminelib/resources/base.py
+++ b/redminelib/resources/base.py
@@ -99,7 +99,9 @@ class BaseResource(utilities.with_metaclass(Registrar)):
     container_one = None
     container_filter = None
     container_create = None
+    noncontainer_create = []
     container_update = None
+    noncontainer_update = []
     query_all_export = None
     query_one_export = None
     query_all = None

--- a/redminelib/resources/standard.py
+++ b/redminelib/resources/standard.py
@@ -393,7 +393,9 @@ class User(BaseResource):
     container_one = 'user'
     container_filter = 'users'
     container_create = 'user'
+    noncontainer_create = ["send_information"]
     container_update = 'user'
+    noncontainer_update = ["send_information"]
     query_all = '/users.json'
     query_one = '/users/{0}.json'
     query_filter = '/users.json'


### PR DESCRIPTION
Before this change send_information field was included in the User
structure but all versions of Redmine expect it at the highest level of
the request params structure (see app/controllers/users_controller.rb).
Because of that account information emails were never sent.