### PR TITLE
Add Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,15 @@ python:
   - 3.9
   - pypy2.7-6.0
   - pypy3.5-6.0
+arch:
+  - amd64
+  - ppc64le
+jobs:
+  exclude: # Disable py versions for power support
+     - arch: ppc64le
+       python: pypy2.7-6.0
+     - arch: ppc64le
+       python: pypy3.5-6.0
 install:
   - pip install -r tests/requirements.txt
   - pip install coveralls


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.