### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/advanced/external_auth.rst
+++ b/docs/advanced/external_auth.rst
@@ -13,7 +13,7 @@ your users if they provide the same login/password they use to login to Redmine:
    user = Redmine('https://redmine.url', username=username, password=password).auth()
 
 If authentication succeeded, ``user`` variable will contain details about the current user, if
-there was an error during authentication proccess, an ``AuthError`` exception will be thrown.
+there was an error during authentication process, an ``AuthError`` exception will be thrown.
 
 If you need more control, for example you want to return your own error message, you can
 intercept ``AuthError`` exception and do what you need, for example:

--- a/redminelib/exceptions.py
+++ b/redminelib/exceptions.py
@@ -111,7 +111,7 @@ class UnknownError(BaseRedmineError):
 
 class ValidationError(BaseRedmineError):
     """
-    Redmine validation errors occured on create/update resource.
+    Redmine validation errors occurred on create/update resource.
     """
     def __init__(self, error):
         super(ValidationError, self).__init__(error)


### PR DESCRIPTION
There are small typos in:
- docs/advanced/external_auth.rst
- redminelib/exceptions.py

Fixes:
- Should read `process` rather than `proccess`.
- Should read `occurred` rather than `occured`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md