### PR TITLE
Fix wrong value of limit in request to Redmine server

### DIFF
--- a/redminelib/engines/base.py
+++ b/redminelib/engines/base.py
@@ -107,7 +107,7 @@ class BaseEngine(object):
                 for num in range(limit - self.chunk, 0, -self.chunk):
                     offset += self.chunk
                     limit -= self.chunk
-                    bulk_params.append(dict(params, offset=offset, limit=limit))
+                    bulk_params.append(dict(params, offset=offset, limit=self.chunk))
 
                 # If we need to make just one more request, there's no point in async
                 if len(bulk_params) == 1:


### PR DESCRIPTION
before:
```
/issues.json?key=2eXXXX&limit=100&offset=0
/issues.json?key=2eXXXX&limit=2959&offset=300
/issues.json?key=2eXXXX&limit=2859&offset=400
/issues.json?key=2eXXXX&limit=2759&offset=500
...
/issues.json?key=2eXXXX&limit=159&offset=2900
/issues.json?key=2eXXXX&limit=59&offset=3000
```

after:
```
/issues.json?key=2eXXXX&limit=100&offset=0
/issues.json?key=2eXXXX&limit=100&offset=300
/issues.json?key=2eXXXX&limit=100&offset=400
/issues.json?key=2eXXXX&limit=100&offset=500
...
/issues.json?key=2eXXXX&limit=100&offset=2900
/issues.json?key=2eXXXX&limit=100&offset=3000
```

However, the Redmine REST API had no real problem because the upper limit for `limit` is 100. https://www.redmine.org/projects/redmine/wiki/Rest_api#Collection-resources-and-pagination