### PR TITLE
Change the key from a query paramter to a HEADER

### DIFF
--- a/redminelib/engines/base.py
+++ b/redminelib/engines/base.py
@@ -34,7 +34,7 @@ class BaseEngine:
 
         # We would like to be authenticated by API key by default
         if options.get('key') is not None:
-            self.requests['params']['key'] = options['key']
+            self.requests['headers']['X-Redmine-API-Key'] = options['key']
         elif options.get('username') is not None and options.get('password') is not None:
             self.requests['auth'] = (options['username'], options['password'])
 


### PR DESCRIPTION
Instead of having the Key being a query parameter in the url (which can shows up in webserver access logs), move it to the header.

https://www.redmine.org/projects/redmine/wiki/Rest_api#Authentication
