### PR TITLE
Added timeout to kwargs for session.request

### DIFF
--- a/redminelib/engines/base.py
+++ b/redminelib/engines/base.py
@@ -60,13 +60,12 @@ class BaseEngine:
         :param data: (required). Data to send in the body of the request.
         :type data: dict, bytes or file-like object
         """
-        kwargs = {'data': data or {}, 'params': params or {}, 'headers': headers or {}}
+
+        kwargs = dict(self.requests, **{'data': data or {}, 'params': params or {}, 'headers': headers or {}})
 
         if method in ('post', 'put', 'patch') and 'Content-Type' not in kwargs['headers']:
             kwargs['data'] = json.dumps(data)
             kwargs['headers']['Content-Type'] = 'application/json'
-        if getattr(self.session, "timeout", None) is not None:
-            kwargs["timeout"] = self.session.timeout
         return kwargs
 
     def request(self, method, url, headers=None, params=None, data=None):

--- a/redminelib/engines/base.py
+++ b/redminelib/engines/base.py
@@ -50,8 +50,7 @@ class BaseEngine:
         """
         raise NotImplementedError
 
-    @staticmethod
-    def construct_request_kwargs(method, headers, params, data):
+    def construct_request_kwargs(self, method, headers, params, data):
         """
         Constructs kwargs that will be used in all requests to Redmine.
 
@@ -66,7 +65,8 @@ class BaseEngine:
         if method in ('post', 'put', 'patch') and 'Content-Type' not in kwargs['headers']:
             kwargs['data'] = json.dumps(data)
             kwargs['headers']['Content-Type'] = 'application/json'
-
+        if getattr(self.session, "timeout", None) is not None:
+            kwargs["timeout"] = self.session.timeout
         return kwargs
 
     def request(self, method, url, headers=None, params=None, data=None):


### PR DESCRIPTION
We can pass optional parameters to Redmine for the requests module. In particular, we can set timeout. But in fact, this timeout was not passed to the requests module, it was simply written to the attribute of the session object.